### PR TITLE
#10 常時SSL化対応

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ yarn-error.log
 /.fleet
 /.idea
 /.vscode
+nginx
+nginx-cert

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace App\Providers;
 
+use Illuminate\Support\Facades\URL;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -19,6 +20,6 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        //
+        URL::forceScheme('https');
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
         "mockery/mockery": "^1.4.4",
         "nunomaduro/collision": "^7.0",
         "phpunit/phpunit": "^10.1",
+        "ryoluo/sail-ssl": "^1.3",
         "spatie/laravel-ignition": "^2.0"
     },
     "autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "84976ea5be73fee4aead38b9eabad1ac",
+    "content-hash": "d1154f20bd8d23f6f62d04391b19e260",
     "packages": [
         {
             "name": "anourvalar/eloquent-serialize",
@@ -9288,6 +9288,68 @@
                 }
             ],
             "time": "2024-03-09T12:04:07+00:00"
+        },
+        {
+            "name": "ryoluo/sail-ssl",
+            "version": "v1.3.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ryoluo/sail-ssl.git",
+                "reference": "afc8cbdbc27a41bbb32a835df02e38a9f937f2bc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ryoluo/sail-ssl/zipball/afc8cbdbc27a41bbb32a835df02e38a9f937f2bc",
+                "reference": "afc8cbdbc27a41bbb32a835df02e38a9f937f2bc",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/console": "^8.0|^9.0|^10.0|^11.0",
+                "illuminate/contracts": "^8.0|^9.0|^10.0|^11.0",
+                "illuminate/support": "^8.0|^9.0|^10.0|^11.0",
+                "php": "^7.3|^8.0|^8.1|^8.2|^8.3"
+            },
+            "require-dev": {
+                "laravel/sail": "^1.14",
+                "orchestra/testbench": "^6.0|^7.0|^8.0|^9.0",
+                "phpunit/phpunit": "^9.5|^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Ryoluo\\SailSsl\\SailSslServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Ryoluo\\SailSsl\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ryo Kobayashi",
+                    "email": "ryoluo@lotus-base.com"
+                }
+            ],
+            "description": "Laravel Sail plugin to enable SSL (HTTPS) connection with Nginx.",
+            "keywords": [
+                "docker",
+                "laravel",
+                "nginx",
+                "sail",
+                "ssl"
+            ],
+            "support": {
+                "issues": "https://github.com/ryoluo/sail-ssl/issues",
+                "source": "https://github.com/ryoluo/sail-ssl"
+            },
+            "time": "2024-03-15T18:32:51+00:00"
         },
         {
             "name": "sebastian/cli-parser",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,25 @@
 services:
+  nginx:
+    image: 'nginx:latest'
+    ports:
+      - '${HTTP_PORT:-8000}:80'
+      - '${SSL_PORT:-443}:443'
+    environment:
+      - SSL_PORT=${SSL_PORT:-443}
+      - APP_SERVICE=${APP_SERVICE:-laravel.test}
+      - SERVER_NAME=${SERVER_NAME:-localhost}
+      - SSL_DOMAIN=${SSL_DOMAIN:-localhost}
+      - SSL_ALT_NAME=${SSL_ALT_NAME:-DNS:localhost}
+    volumes:
+      - 'sail-nginx:/etc/nginx/certs'
+      - './vendor/ryoluo/sail-ssl/nginx/templates:/etc/nginx/templates'
+      - './vendor/ryoluo/sail-ssl/nginx/generate-ssl-cert.sh:/docker-entrypoint.d/99-generate-ssl-cert.sh'
+      - './nginx-cert/local.mikatan-knitting.com+2-key.pem:/etc/certs/local.mikatan-knitting.com+2-key.pem'
+      - './nginx-cert/local.mikatan-knitting.com+2.pem:/etc/certs/local.mikatan-knitting.com+2.pem'
+    depends_on:
+      - ${APP_SERVICE:-laravel.test}
+    networks:
+      - sail
   mikatan-laravel:
     build:
       context: ./docker/8.3
@@ -52,5 +73,7 @@ networks:
   sail:
     driver: bridge
 volumes:
+  sail-nginx:
+    driver: local
   sail-mysql:
     driver: local


### PR DESCRIPTION
## 修正背景
- SSL対応のため

## 対応内容
- 自己署名証明書を作成
- sail-sslプラグインをインストール
- 常時httpsでアクセスされるように変更

## 画面キャプチャ(after)
<img width="1440" alt="image" src="https://github.com/posiposi/mikatan-knitting/assets/88781098/76213243-49d5-4156-bbc2-d77ffa50ee77">

## マージタイミング
- いつでも

## テスト内容
- [x] 各ページでhttps接続できること
- [x] https接続してもブラウザ警告が発生しないこと
