### PR TITLE
#11 商品テーブルの商品状態カラムの定義変更

### DIFF
--- a/backend/infrastructure/prisma/schema.prisma
+++ b/backend/infrastructure/prisma/schema.prisma
@@ -22,7 +22,7 @@ model User {
 model Item {
   id           String    @id @default(uuid()) @db.Char(26)
   item_name    String
-  status       String
+  stock        Boolean   @default(true)
   user_id      String?
   description  String?
   purchased_at DateTime?

--- a/backend/infrastructure/prisma/schema.prisma
+++ b/backend/infrastructure/prisma/schema.prisma
@@ -23,7 +23,7 @@ model Item {
   id           String    @id @default(uuid()) @db.Char(26)
   item_name    String
   stock        Boolean   @default(true)
-  user_id      String?
+  user_id      String?   @db.Char(26)
   description  String?
   purchased_at DateTime?
   created_at   DateTime  @default(now())

--- a/backend/infrastructure/prisma/schema.prisma
+++ b/backend/infrastructure/prisma/schema.prisma
@@ -28,7 +28,7 @@ model Item {
   purchased_at DateTime?
   created_at   DateTime  @default(now())
   updated_at   DateTime?
-  users        User?     @relation(fields: [user_id], references: [id])
+  users        User?     @relation(fields: [user_id], references: [id], onDelete: Cascade)
   price        Price?
 
   @@map("items")
@@ -42,7 +42,7 @@ model Price {
   tax_rate          Int      @default(10)
   created_at        DateTime @default(now())
   updated_at        DateTime?
-  item              Item     @relation(fields: [item_id], references: [id])
+  item              Item     @relation(fields: [item_id], references: [id], onDelete: Cascade)
 
   @@map("prices")
 }


### PR DESCRIPTION
## 変更点
- [issue](https://github.com/posiposi/mikatan-knitting/issues/11)の通り
- user_idの型変更、リレーションのCascade追加も同時対応